### PR TITLE
Fix out-of-space issue

### DIFF
--- a/ansible/hosts.yml
+++ b/ansible/hosts.yml
@@ -14,7 +14,7 @@ all:
               create: true
               lvnames:
                 - lvname: docker
-                  size: 5g
+                  size: 15g
                   create: true
                   filesystem: ext4
                   mount: true

--- a/compose/application.yml
+++ b/compose/application.yml
@@ -29,7 +29,7 @@ services:
         restart: always
         cap_add:
             - SYS_NICE # TODO: investigate if it is ok to use # https://github.com/docker-library/mysql/issues/303
-        command: --default-authentication-plugin=mysql_native_password
+        command: --default-authentication-plugin=mysql_native_password --disable-log-bin
         healthcheck:
             start_period: 20s
             interval: 5s

--- a/compose/application.yml
+++ b/compose/application.yml
@@ -50,6 +50,7 @@ services:
             - ../conf/application/scripts:/tmp/scripts
         networks:
             - application
+        restart: always
         depends_on:
             mysql01:
                 condition: service_healthy

--- a/compose/monitoring.yml
+++ b/compose/monitoring.yml
@@ -26,7 +26,6 @@ services:
           - 9090
         networks:
           - monitoring
-        # user: root # TODO: remove
         restart: always
 
     ingress_monitoring01:

--- a/compose/monitoring.yml
+++ b/compose/monitoring.yml
@@ -20,6 +20,7 @@ services:
           - '--web.external-url=http://0.0.0.0:9090'
           - '--storage.tsdb.path=/prometheus'
           - '--storage.tsdb.retention=5d' # TODO: decide a value
+          - '--storage.tsdb.retention.size=5GB'
           - '--web.enable-lifecycle'
         expose:
           - 9090

--- a/conf/application/scripts/run.sh
+++ b/conf/application/scripts/run.sh
@@ -10,14 +10,13 @@ prepare(){
     --db-driver=mysql \
     --oltp-table-size=10000 \
     --oltp-tables-count="$tables" \
-    --threads=1 \
     --mysql-host="${MYSQL_HOST}" \
     --mysql-port="${MYSQL_PORT}" \
     --mysql-user="${MYSQL_USER}" \
     --mysql-password="${MYSQL_PASSWORD}" \
-    --mysql-db="application" \
-    /usr/share/sysbench/tests/include/oltp_legacy/parallel_prepare.lua \
-    run
+    --mysql-db="${MYSQL_DATABASE}" \
+    /usr/share/sysbench/tests/include/oltp_legacy/oltp.lua \
+    prepare
 }
 
 benchmark(){
@@ -44,6 +43,7 @@ clean(){
     sysbench \
     --db-driver=mysql \
     --oltp-tables-count="$tables" \
+    --oltp-table-size=10000 \
     --mysql-host="${MYSQL_HOST}" \
     --mysql-port="${MYSQL_PORT}" \
     --mysql-user="${MYSQL_USER}" \
@@ -54,16 +54,11 @@ clean(){
 }
 
 run(){
-    index=1
     while true; do
         sleep 10
-        if [ "$(( index%5 ))" -eq 0 ]; then
-            clean
-            prepare
-        else
-            benchmark
-        fi
-        (( index++ ))
+        benchmark
+        clean
+        prepare
     done
 }
 


### PR DESCRIPTION
Currently, the `mysql01` container has a bug and grows constantly in size due to `binlog`. `binlog` is a MySQL utility that's used for replication, it stores all the statements sent to MySQL in order to replicate them among `slaves`. It is overflooding the disk by appending all the `sysbench` queries to a binlog file. This PR disables `binlog` since there is no replication.

This PR also:
- simplifies the `application` logic
- adds 10 more GBs to the `docker` LV partition
- sets a max limit for `prometheus` data
- restart `always` the application